### PR TITLE
ci: validate action metadata schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.3.1
       - name: Validate Action
-        uses: meza/action-validate-action@v1.0.1
+        uses: cardinalby/schema-validator-action@2166123eb256fa40baef7e22ab1379708425efc7 # 3.1.1
+        with:
+          file: action.yml
+          schema: https://raw.githubusercontent.com/SchemaStore/schemastore/773fe876b57bb3d35693177b626164570a6bac49/src/schemas/json/github-action.json
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4.2.2
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,9 @@ name: "Verify PR"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify PR
@@ -11,4 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.3.1
       - name: Validate Action
-        uses: meza/action-validate-action@v1.0.1
+        uses: cardinalby/schema-validator-action@2166123eb256fa40baef7e22ab1379708425efc7 # 3.1.1
+        with:
+          file: action.yml
+          schema: https://raw.githubusercontent.com/SchemaStore/schemastore/773fe876b57bb3d35693177b626164570a6bac49/src/schemas/json/github-action.json


### PR DESCRIPTION
## What changed

- replace the internal action validator wrapper with the pinned generic schema validator
- validate action.yml against the GitHub Action SchemaStore schema pinned to an immutable commit
- grant the PR verification workflow contents read permission

## Why

The existing validation chain depends on internal installer and wrapper actions. Direct schema validation removes those dependencies while retaining the intended metadata check.

## Impact

Action runtime behavior and public inputs are unchanged. PR and release workflows now validate action metadata directly.

## Validation

- action-validator v0.9.0 passed for action.yml
- the validator binary matched its GitHub release SHA-256 digest
- git diff --check passed